### PR TITLE
Fix SegFault on serialization of objects

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -1184,24 +1184,28 @@ PHP_MINIT_FUNCTION(gearman) {
 	gearman_client_ce->create_object = gearman_client_obj_new;
 	memcpy(&gearman_client_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_client_obj_handlers));
 	gearman_client_obj_handlers.offset = XtOffsetOf(gearman_client_obj, std);
+	gearman_client_obj_handlers.free_obj = gearman_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanTask", gearman_task_methods);
 	gearman_task_ce = zend_register_internal_class(&ce);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
 	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);
+	gearman_task_obj_handlers.free_obj = gearman_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanWorker", gearman_worker_methods);
 	gearman_worker_ce = zend_register_internal_class(&ce);
 	gearman_worker_ce->create_object = gearman_worker_obj_new;
 	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_worker_obj_handlers));
 	gearman_worker_obj_handlers.offset = XtOffsetOf(gearman_worker_obj, std);
+	gearman_worker_obj_handlers.free_obj = gearman_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanJob", gearman_job_methods);
 	gearman_job_ce = zend_register_internal_class(&ce);
 	gearman_job_ce->create_object = gearman_job_obj_new;
 	memcpy(&gearman_job_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_job_obj_handlers));
 	gearman_job_obj_handlers.offset = XtOffsetOf(gearman_job_obj, std);
+	gearman_job_obj_handlers.free_obj = gearman_free_obj;
 
 	/* XXX exception class */
 	INIT_CLASS_ENTRY(ce, "GearmanException", gearman_exception_methods)
@@ -1720,6 +1724,10 @@ zend_module_entry gearman_module_entry = {
 	PHP_GEARMAN_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
+
+/* {{{ gearman_free_obj */
+static void gearman_free_obj() {}
+/* }}} */
 
 #ifdef COMPILE_DL_GEARMAN
 ZEND_GET_MODULE(gearman)

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -1060,7 +1060,6 @@ zend_function_entry gearman_methods[]= {
 
 static zend_function_entry gearman_client_methods[]= {
 	PHP_ME(GearmanClient, __construct, arginfo_gearman_client_construct, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
-	PHP_ME(GearmanClient, __destruct, arginfo_oo_gearman_client_destruct, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_client_return_code, arginfo_oo_gearman_client_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(error, gearman_client_error, arginfo_oo_gearman_client_error, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(getErrno, gearman_client_get_errno, arginfo_oo_gearman_client_get_errno, ZEND_ACC_PUBLIC)
@@ -1112,7 +1111,6 @@ static zend_function_entry gearman_client_methods[]= {
 
 zend_function_entry gearman_task_methods[]= {
 	PHP_ME(GearmanTask, __construct, arginfo_oo_gearman_task_construct, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
-	PHP_ME(GearmanTask, __destruct, arginfo_oo_gearman_task_destruct, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_task_return_code, arginfo_oo_gearman_task_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(functionName, gearman_task_function_name, arginfo_oo_gearman_task_function_name, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(unique, gearman_task_unique, arginfo_oo_gearman_task_unique, ZEND_ACC_PUBLIC)
@@ -1130,7 +1128,6 @@ zend_function_entry gearman_task_methods[]= {
 
 zend_function_entry gearman_worker_methods[]= {
 	PHP_ME(GearmanWorker, __construct, arginfo_oo_gearman_worker_construct, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
-	PHP_ME(GearmanWorker, __destruct, arginfo_oo_gearman_worker_destruct, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_worker_return_code, arginfo_oo_gearman_worker_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(error, gearman_worker_error, arginfo_oo_gearman_worker_error, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(getErrno, gearman_worker_errno, arginfo_oo_gearman_worker_errno, ZEND_ACC_PUBLIC)
@@ -1155,7 +1152,6 @@ zend_function_entry gearman_worker_methods[]= {
 };
 
 zend_function_entry gearman_job_methods[]= {
-	PHP_ME(GearmanJob, __destruct, arginfo_oo_gearman_job_destruct, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(returnCode, gearman_job_return_code, arginfo_oo_gearman_job_return_code, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(setReturn, gearman_job_set_return, arginfo_oo_gearman_job_set_return, ZEND_ACC_PUBLIC)
 	PHP_ME_MAPPING(sendData, gearman_job_send_data, arginfo_oo_gearman_job_send_data, ZEND_ACC_PUBLIC)
@@ -1184,28 +1180,28 @@ PHP_MINIT_FUNCTION(gearman) {
 	gearman_client_ce->create_object = gearman_client_obj_new;
 	memcpy(&gearman_client_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_client_obj_handlers));
 	gearman_client_obj_handlers.offset = XtOffsetOf(gearman_client_obj, std);
-	gearman_client_obj_handlers.free_obj = gearman_free_obj;
+	gearman_client_obj_handlers.free_obj = gearman_client_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanTask", gearman_task_methods);
 	gearman_task_ce = zend_register_internal_class(&ce);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
 	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);
-	gearman_task_obj_handlers.free_obj = gearman_free_obj;
+	gearman_task_obj_handlers.free_obj = gearman_task_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanWorker", gearman_worker_methods);
 	gearman_worker_ce = zend_register_internal_class(&ce);
 	gearman_worker_ce->create_object = gearman_worker_obj_new;
 	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_worker_obj_handlers));
 	gearman_worker_obj_handlers.offset = XtOffsetOf(gearman_worker_obj, std);
-	gearman_worker_obj_handlers.free_obj = gearman_free_obj;
+	gearman_worker_obj_handlers.free_obj = gearman_worker_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanJob", gearman_job_methods);
 	gearman_job_ce = zend_register_internal_class(&ce);
 	gearman_job_ce->create_object = gearman_job_obj_new;
 	memcpy(&gearman_job_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_job_obj_handlers));
 	gearman_job_obj_handlers.offset = XtOffsetOf(gearman_job_obj, std);
-	gearman_job_obj_handlers.free_obj = gearman_free_obj;
+	gearman_job_obj_handlers.free_obj = gearman_job_free_obj;
 
 	/* XXX exception class */
 	INIT_CLASS_ENTRY(ce, "GearmanException", gearman_exception_methods)
@@ -1724,10 +1720,6 @@ zend_module_entry gearman_module_entry = {
 	PHP_GEARMAN_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
-
-/* {{{ gearman_free_obj */
-static void gearman_free_obj() {}
-/* }}} */
 
 #ifdef COMPILE_DL_GEARMAN
 ZEND_GET_MODULE(gearman)

--- a/php_gearman.h
+++ b/php_gearman.h
@@ -43,4 +43,6 @@ extern zend_class_entry *gearman_exception_ce;
 void *_php_malloc(size_t size, void *arg);
 void _php_free(void *ptr, void *arg);
 
+static void gearman_free_obj();
+
 #endif  /* __PHP_GEARMAN_H */

--- a/php_gearman.h
+++ b/php_gearman.h
@@ -43,6 +43,4 @@ extern zend_class_entry *gearman_exception_ce;
 void *_php_malloc(size_t size, void *arg);
 void _php_free(void *ptr, void *arg);
 
-static void gearman_free_obj();
-
 #endif  /* __PHP_GEARMAN_H */

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -71,12 +71,9 @@ PHP_METHOD(GearmanClient, __construct)
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::__destruct()
-   cleans up GearmanClient object */
-PHP_METHOD(GearmanClient, __destruct)
-{
+void gearman_client_free_obj(zend_object *object) {
         char *context = NULL;
-        gearman_client_obj *intern = Z_GEARMAN_CLIENT_P(getThis());
+        gearman_client_obj *intern = gearman_client_fetch_object(object);
         if (!intern) {
                 return;
         }

--- a/php_gearman_client.h
+++ b/php_gearman_client.h
@@ -72,9 +72,10 @@ gearman_client_obj *gearman_client_fetch_object(zend_object *obj);
 					  (__ret) == GEARMAN_WORK_WARNING || \
 					  (__ret) == GEARMAN_WORK_FAIL)
 
+void gearman_client_free_obj(zend_object *object);
+
 PHP_FUNCTION(gearman_client_create);
 PHP_METHOD(GearmanClient, __construct);
-PHP_METHOD(GearmanClient, __destruct);
 PHP_FUNCTION(gearman_client_return_code);
 PHP_FUNCTION(gearman_client_error);
 PHP_FUNCTION(gearman_client_get_errno);

--- a/php_gearman_job.c
+++ b/php_gearman_job.c
@@ -15,21 +15,6 @@ gearman_job_obj *gearman_job_fetch_object(zend_object *obj) {
         return (gearman_job_obj *)((char*)(obj) - XtOffsetOf(gearman_job_obj, std));
 }
 
-/* {{{ proto object GearmanJob::__destruct()
-   cleans up GearmanJob object */
-PHP_METHOD(GearmanJob, __destruct) {
-        gearman_job_obj *intern = Z_GEARMAN_JOB_P(getThis());
-        if (!intern) {
-                return;
-        }    
-
-        if (intern->flags & GEARMAN_JOB_OBJ_CREATED) {
-                gearman_job_free(intern->job);
-        }    
-
-        zend_object_std_dtor(&intern->std);
-}
-
 zend_object *gearman_job_obj_new(zend_class_entry *ce) {
         gearman_job_obj *intern = ecalloc(1,
                 sizeof(gearman_job_obj) +
@@ -41,6 +26,21 @@ zend_object *gearman_job_obj_new(zend_class_entry *ce) {
         intern->std.handlers = &gearman_job_obj_handlers;
         return &intern->std;
 }
+
+/* {{{ gearman_job_free_obj */
+void gearman_job_free_obj(zend_object *object) {
+        gearman_job_obj *intern = gearman_job_fetch_object(object);
+        if (!intern) {
+                return;
+        }
+
+        if (intern->flags & GEARMAN_JOB_OBJ_CREATED) {
+                gearman_job_free(intern->job);
+        }
+
+        zend_object_std_dtor(&intern->std);
+}
+/* }}} */
 
 /* {{{ proto int gearman_job_return_code()
    get last gearman_return_t */

--- a/php_gearman_job.h
+++ b/php_gearman_job.h
@@ -45,7 +45,8 @@ typedef struct {
 gearman_job_obj *gearman_job_fetch_object(zend_object *obj);
 #define Z_GEARMAN_JOB_P(zv) gearman_job_fetch_object(Z_OBJ_P((zv)))
 
-PHP_METHOD(GearmanJob, __destruct);
+void gearman_job_free_obj(zend_object *object);
+
 PHP_FUNCTION(gearman_job_return_code);
 PHP_FUNCTION(gearman_job_set_return);
 PHP_FUNCTION(gearman_job_send_data);

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -127,10 +127,8 @@ gearman_return_t _php_task_fail_fn(gearman_task_st *task) {
 PHP_METHOD(GearmanTask, __construct) {
 }
 
-/* {{{ proto object GearmanTask::__destruct()
-   Destroys a task object */
-PHP_METHOD(GearmanTask, __destruct) {
-        gearman_task_obj *intern = Z_GEARMAN_TASK_P(getThis());
+void gearman_task_free_obj(zend_object *object) {
+        gearman_task_obj *intern = gearman_task_fetch_object(object);
         if (!intern) {
                 return;
         }    

--- a/php_gearman_task.h
+++ b/php_gearman_task.h
@@ -61,8 +61,9 @@ gearman_return_t _php_task_complete_fn(gearman_task_st *task);
 gearman_return_t _php_task_exception_fn(gearman_task_st *task);
 gearman_return_t _php_task_fail_fn(gearman_task_st *task);
 
+void gearman_task_free_obj(zend_object *object);
+
 PHP_METHOD(GearmanTask, __construct);
-PHP_METHOD(GearmanTask, __destruct);
 PHP_FUNCTION(gearman_task_return_code);
 PHP_FUNCTION(gearman_task_function_name);
 PHP_FUNCTION(gearman_task_unique);

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -57,10 +57,8 @@ PHP_METHOD(GearmanWorker, __construct) {
 }
 /* }}} */
 
-/* {{{ proto object GearmanWorker::__destruct()
-   Destroys a worker object */
-PHP_METHOD(GearmanWorker, __destruct) {
-	gearman_worker_obj *intern = Z_GEARMAN_WORKER_P(getThis());
+void gearman_worker_free_obj(zend_object *object) {
+    gearman_worker_obj *intern = gearman_worker_fetch_object(object);
 
 	if (!intern)  {
 		return;

--- a/php_gearman_worker.h
+++ b/php_gearman_worker.h
@@ -54,9 +54,10 @@ typedef struct {
 gearman_worker_obj *gearman_worker_fetch_object(zend_object *obj);
 #define Z_GEARMAN_WORKER_P(zv) gearman_worker_fetch_object(Z_OBJ_P((zv)))
 
+void gearman_worker_free_obj(zend_object *object);
+
 PHP_FUNCTION(gearman_worker_create);
 PHP_METHOD(GearmanWorker, __construct);
-PHP_METHOD(GearmanWorker, __destruct);
 PHP_FUNCTION(gearman_worker_return_code);
 PHP_FUNCTION(gearman_worker_error);
 PHP_FUNCTION(gearman_worker_errno);

--- a/tests/gearman_client_022.phpt
+++ b/tests/gearman_client_022.phpt
@@ -1,0 +1,21 @@
+--TEST--
+unserialize(serialize(GearmanClient))
+--SKIPIF--
+<?php if (!extension_loaded("gearman")) print "skip"; ?>
+--FILE--
+<?php
+
+$i = 0;
+while ($i <= 5) {
+    echo $i;
+    $job = new GearmanClient();
+    unserialize(serialize($job));
+    $i++;
+}
+print PHP_EOL;
+
+print "OK";
+?>
+--EXPECT--
+012345
+OK

--- a/tests/gearman_client_022.phpt
+++ b/tests/gearman_client_022.phpt
@@ -8,8 +8,8 @@ unserialize(serialize(GearmanClient))
 $i = 0;
 while ($i <= 5) {
     echo $i;
-    $job = new GearmanClient();
-    unserialize(serialize($job));
+    $client = new GearmanClient();
+    unserialize(serialize($client));
     $i++;
 }
 print PHP_EOL;

--- a/tests/gearman_job_003.phpt
+++ b/tests/gearman_job_003.phpt
@@ -1,0 +1,21 @@
+--TEST--
+unserialize(serialize(GearmanJob))
+--SKIPIF--
+<?php if (!extension_loaded("gearman")) print "skip"; ?>
+--FILE--
+<?php
+
+$i = 0;
+while ($i <= 5) {
+    echo $i;
+    $job = new GearmanJob();
+    unserialize(serialize($job));
+    $i++;
+}
+print PHP_EOL;
+
+print "OK";
+?>
+--EXPECT--
+012345
+OK

--- a/tests/gearman_task_006.phpt
+++ b/tests/gearman_task_006.phpt
@@ -1,0 +1,21 @@
+--TEST--
+unserialize(serialize(GearmanTask))
+--SKIPIF--
+<?php if (!extension_loaded("gearman")) print "skip"; ?>
+--FILE--
+<?php
+
+$i = 0;
+while ($i <= 5) {
+    echo $i;
+    $client = new GearmanTask();
+    unserialize(serialize($client));
+    $i++;
+}
+print PHP_EOL;
+
+print "OK";
+?>
+--EXPECT--
+012345
+OK

--- a/tests/gearman_worker_017.phpt
+++ b/tests/gearman_worker_017.phpt
@@ -1,0 +1,21 @@
+--TEST--
+unserialize(serialize(GearmanWorker))
+--SKIPIF--
+<?php if (!extension_loaded("gearman")) print "skip"; ?>
+--FILE--
+<?php
+
+$i = 0;
+while ($i <= 5) {
+    echo $i;
+    $client = new GearmanWorker();
+    unserialize(serialize($client));
+    $i++;
+}
+print PHP_EOL;
+
+print "OK";
+?>
+--EXPECT--
+012345
+OK


### PR DESCRIPTION
I've encountered a problem with upgrading a codebase to PHP 7.4 using the [latest build](https://github.com/php/pecl-networking-gearman/commit/fb7a1545edd1e23365a59b302878e225453919c2) of this extension. 

In this situation we have some objects which contain a GearmanJob object. When serializing and unserializing a bunch of them you'll get a Segmentation Fault.

I'm not familiar with writing code in C and I'm not sure this is the proper solution to the problem.
So correct me if I'm wrong here! However it solves my problem and doesn't introduce any new once... **according to the testsuite** 😜