### PR TITLE
Use SKIP_ONLINE_TESTS

### DIFF
--- a/tests/gearman_client_012.phpt
+++ b/tests/gearman_client_012.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::addServer(), gearman_client_add_server()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_013.phpt
+++ b/tests/gearman_client_013.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::addServers(), gearman_client_add_servers()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_014.phpt
+++ b/tests/gearman_client_014.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::wait(), gearman_client_wait()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_015.phpt
+++ b/tests/gearman_client_015.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::doJobHandle(), gearman_client_do_job_handle()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_016.phpt
+++ b/tests/gearman_client_016.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::doStatus(), gearman_client_do_status()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_017.phpt
+++ b/tests/gearman_client_017.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::jobStatus(), gearman_client_job_status()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_018.phpt
+++ b/tests/gearman_client_018.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::jobStatusByUniqueKey(), gearman_client_job_status_by_unique_key()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_019.phpt
+++ b/tests/gearman_client_019.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::ping(), gearman_client_ping()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_020.phpt
+++ b/tests/gearman_client_020.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::clearCallbacks(), gearman_client_clear_callbacks()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_client_integration_test_001.phpt
+++ b/tests/gearman_client_integration_test_001.phpt
@@ -1,7 +1,10 @@
 --TEST--
 
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php
+require_once('skipif.inc');
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php
 

--- a/tests/gearman_client_integration_test_002.phpt
+++ b/tests/gearman_client_integration_test_002.phpt
@@ -3,7 +3,9 @@ GearmanClient::setStatusCallback(), gearman_client_set_status_callback(),
 GearmanClient::addTaskStatus(), gearman_client_add_task_status(),
 GearmanClient::runTasks(), gearman_client_run_tasks()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php
 function reverse_status($task, $context)

--- a/tests/gearman_task_001.phpt
+++ b/tests/gearman_task_001.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanTask::functionName, gearman_task_function_name
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_task_002.phpt
+++ b/tests/gearman_task_002.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanTask::unique, gearman_task_unique
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_task_003.phpt
+++ b/tests/gearman_task_003.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanTask::jobHandle(), gearman_task_job_handle()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_task_004.phpt
+++ b/tests/gearman_task_004.phpt
@@ -4,7 +4,9 @@ GearmanTask::is_running(), gearman_task_is_running(),
 GearmanTask::numerator(), gearman_task_numerator(),
 GearmanTask::denominator(), gearman_task_denominator()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_task_005.phpt
+++ b/tests/gearman_task_005.phpt
@@ -2,7 +2,9 @@
 GearmanTask::data(), gearman_task_data(),
 GearmanTask::dataSize(), gearman_task_data_size()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_010.phpt
+++ b/tests/gearman_worker_010.phpt
@@ -1,10 +1,8 @@
 --TEST--
 gearman_worker_add_server(), gearman_worker_add_servers()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; 
-/*
-TODO - requires gearmand to be running
-*/
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
 ?>
 --FILE--
 <?php 

--- a/tests/gearman_worker_011.phpt
+++ b/tests/gearman_worker_011.phpt
@@ -1,7 +1,9 @@
 --TEST--
 gearman_worker_wait()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_012.phpt
+++ b/tests/gearman_worker_012.phpt
@@ -2,9 +2,7 @@
 gearman_worker_register(), gearman_worker_unregister(), gearman_worker_unregister_all()
 --SKIPIF--
 <?php if (!extension_loaded("gearman")) print "skip";
-/*
-TODO - requires gearmand to be running
-*/
+require_once('skipifconnect.inc');
 ?>
 --FILE--
 <?php 

--- a/tests/gearman_worker_013.phpt
+++ b/tests/gearman_worker_013.phpt
@@ -2,9 +2,7 @@
 gearman_worker_add_function()
 --SKIPIF--
 <?php if (!extension_loaded("gearman")) print "skip";
-/*
-TODO - requires gearmand to be running
-*/
+require_once('skipifconnect.inc');
 ?>
 --FILE--
 <?php 

--- a/tests/gearman_worker_014.phpt
+++ b/tests/gearman_worker_014.phpt
@@ -2,9 +2,7 @@
 gearman_worker_work()
 --SKIPIF--
 <?php if (!extension_loaded("gearman")) print "skip"; 
-/*
-TODO - requires gearmand to be running
-*/
+require_once('skipifconnect.inc');
 ?>
 --FILE--
 <?php 

--- a/tests/gearman_worker_015.phpt
+++ b/tests/gearman_worker_015.phpt
@@ -1,7 +1,9 @@
 --TEST--
 gearman_worker_ping()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 

--- a/tests/gearman_worker_016.phpt
+++ b/tests/gearman_worker_016.phpt
@@ -2,9 +2,7 @@
 GearmanWorker::addFunction(), context param
 --SKIPIF--
 <?php if (!extension_loaded("gearman")) print "skip";
-/*
-TODO - requires gearmand to be running
-*/
+require_once('skipifconnect.inc');
 ?>
 --FILE--
 <?php 

--- a/tests/skipifconnect.inc
+++ b/tests/skipifconnect.inc
@@ -1,5 +1,7 @@
 <?php
 
+if (getenv("SKIP_ONLINE_TESTS")) die("skip online test");
+
 require_once('connect.inc');
 
 $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);


### PR DESCRIPTION
When gearmand is not running tests could use `SKIP_ONLINE_TESTS` environment variable to by-pass connection

Follow-up to https://github.com/php/pecl-networking-gearman/pull/3#issuecomment-761523752