### PR TITLE
fixed memory leak in GearmanClient::doXXX methods

### DIFF
--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -417,7 +417,8 @@ static void gearman_client_do_work_handler(void* (*do_work_func)(
                 RETURN_EMPTY_STRING();
         }
 
-        RETURN_STRINGL((char *)result, (long) result_size);
+        ZVAL_STRINGL(return_value, (char *)result, (long)result_size);
+        efree(result);
 }
 /* }}} */
 


### PR DESCRIPTION
There is a memory leak in the latest client when non-empty string (result) is returned from the worker.

See examples in gearmand - reverse_client.cc:
```
result= (char *)gearman_client_do(&client, "reverse", NULL,
                                      text_to_echo.c_str(), text_to_echo.size(),
                                      &result_size, &ret);
...
free(result)
```
The result must be freed. My fix only copies the result to the return value and frees the allocated memory.

my environment: CentOS8 with
libgearman.x86_64                             1.1.19.1-1.el8                           @epel        
php-pecl-gearman.x86_64                  2.1.0-1.el8.remi.7.3                  @remi-modular
