### PR TITLE
Fix return types in proto comments

### DIFF
--- a/gearman.stub.php
+++ b/gearman.stub.php
@@ -14,16 +14,16 @@ class GearmanClient {
     public function __destruct() {}
 
     /** @alias gearman_client_return_code */
-    public function returnCode(): ?int {}
+    public function returnCode(): int {}
 
     /** @alias gearman_client_error */
-    public function error(): string|false|null {}
+    public function error(): string|false {}
 
     /** @alias gearman_client_get_errno */
-    public function getErrno(): ?int {}
+    public function getErrno(): int {}
 
     /** @alias gearman_client_options */
-    public function options(): ?int {}
+    public function options(): int {}
 
     /** @alias gearman_client_set_options */
     public function setOptions(int $option): bool {}
@@ -35,7 +35,7 @@ class GearmanClient {
     public function removeOptions(int $option): bool {}
 
     /** @alias gearman_client_timeout */
-    public function timeout(): ?int {}
+    public function timeout(): int {}
 
     /** @alias gearman_client_set_timeout */
     public function setTimeout(int $timeout): bool {}
@@ -144,10 +144,10 @@ class GearmanClient {
 
 }
 
-function gearman_client_return_code(GearmanClient $obj): ?int {}
-function gearman_client_error(GearmanClient $obj): null|string|false {}
-function gearman_client_get_errno(GearmanClient $obj): ?int {}
-function gearman_client_options(GearmanClient $obj): ?int {}
+function gearman_client_return_code(GearmanClient $obj): int {}
+function gearman_client_error(GearmanClient $obj): string|false {}
+function gearman_client_get_errno(GearmanClient $obj): int {}
+function gearman_client_options(GearmanClient $obj): int {}
 function gearman_client_set_options(GearmanClient $obj, int $option): bool {}
 function gearman_client_add_options(GearmanClient $obj, int $option): bool {}
 function gearman_client_remove_options(GearmanClient $obj, int $option): bool {}
@@ -192,13 +192,13 @@ class GearmanJob {
     public function __destruct() {}
 
     /** @alias gearman_job_return_code */
-    public function returnCode(): ?int {}
+    public function returnCode(): int {}
 
     /** @alias gearman_job_set_return */
-    public function setReturn(int $gearman_return_t): ?bool {}
+    public function setReturn(int $gearman_return_t): bool {}
 
     /** @alias gearman_job_send_data */
-    public function sendData(string $data): ?bool {}
+    public function sendData(string $data): bool {}
 
     /** @alias gearman_job_send_warning */
     public function sendWarning(string $warning): bool {}
@@ -216,34 +216,34 @@ class GearmanJob {
     public function sendFail(): bool {}
 
     /** @alias gearman_job_handle */
-    public function handle(): bool|string {}
+    public function handle(): false|string {}
 
     /** @alias gearman_job_function_name */
-    public function functionName(): bool|string {}
+    public function functionName(): false|string {}
 
     /** @alias gearman_job_unique */
-    public function unique(): bool|string {}
+    public function unique(): false|string {}
 
     /** @alias gearman_job_workload */
     public function workload(): string {}
 
     /** @alias gearman_job_workload_size */
-    public function workloadSize(): ?int {}
+    public function workloadSize(): int {}
 }
 
-function gearman_job_return_code(GearmanJob $obj): ?int {}
-function gearman_job_set_return(GearmanJob $obj, int $gearman_return_t): ?bool {}
-function gearman_job_send_data(GearmanJob $obj, string $data): ?bool {}
+function gearman_job_return_code(GearmanJob $obj): int {}
+function gearman_job_set_return(GearmanJob $obj, int $gearman_return_t): bool {}
+function gearman_job_send_data(GearmanJob $obj, string $data): bool {}
 function gearman_job_send_warning(GearmanJob $obj, string $warning): bool {}
 function gearman_job_send_status(GearmanJob $obj, int $numerator, int $denominator): bool {}
 function gearman_job_send_complete(GearmanJob $obj, string $result): bool {}
 function gearman_job_send_exception(GearmanJob $obj, string $exception): bool {}
 function gearman_job_send_fail(GearmanJob $obj): bool {}
-function gearman_job_handle(GearmanJob $obj): bool|string {}
-function gearman_job_function_name(GearmanJob $obj): bool|string {}
-function gearman_job_unique(GearmanJob $obj): bool|string {}
+function gearman_job_handle(GearmanJob $obj): false|string {}
+function gearman_job_function_name(GearmanJob $obj): false|string {}
+function gearman_job_unique(GearmanJob $obj): false|string {}
 function gearman_job_workload(GearmanJob $obj): string {}
-function gearman_job_workload_size(GearmanJob $obj): ?int {}
+function gearman_job_workload_size(GearmanJob $obj): int {}
 
 class GearmanTask {
 
@@ -253,28 +253,28 @@ class GearmanTask {
     public function returnCode(): int {}
 
     /** @alias gearman_task_function_name */
-    public function functionName(): null|false|string {}
+    public function functionName(): false|string {}
 
     /** @alias gearman_task_unique */
-    public function unique(): bool|string {}
+    public function unique(): false|string {}
 
     /** @alias gearman_task_job_handle */
-    public function jobHandle(): null|false|string {}
+    public function jobHandle(): false|string {}
 
     /** @alias gearman_task_is_known */
-    public function isKnown(): ?bool {}
+    public function isKnown(): bool {}
 
     /** @alias gearman_task_is_running */
-    public function isRunning(): ?bool {}
+    public function isRunning(): bool {}
 
     /** @alias gearman_task_numerator */
-    public function taskNumerator(): ?bool|int {}
+    public function taskNumerator(): false|int {}
 
     /** @alias gearman_task_denominator */
-    public function taskDenominator(): ?bool|int {}
+    public function taskDenominator(): false|int {}
 
     /** @alias gearman_task_data */
-    public function data(): bool|string {}
+    public function data(): false|string {}
 
     /** @alias gearman_task_data_size */
     public function dataSize(): int|false {}
@@ -283,52 +283,52 @@ class GearmanTask {
     public function sendWorkload(string $data): int|false {}
 
     /** @alias gearman_task_recv_data */
-    public function recvData(int $data_len): null|false|array {}
+    public function recvData(int $data_len): false|array {}
 }
 
-function gearman_task_return_code(GearmanTask $obj): ?int {}
-function gearman_task_function_name(GearmanTask $obj): null|bool|string {}
-function gearman_task_unique(GearmanTask $obj): null|bool|string {}
-function gearman_task_job_handle(GearmanTask $obj): null|bool|string {}
-function gearman_task_is_known(GearmanTask $obj): ?bool {}
-function gearman_task_is_running(GearmanTask $obj): ?bool {}
-function gearman_task_numerator(GearmanTask $obj): null|bool|int {}
-function gearman_task_denominator(GearmanTask $obj): null|bool|int {}
-function gearman_task_data(GearmanTask $obj): null|bool|string {}
+function gearman_task_return_code(GearmanTask $obj): int {}
+function gearman_task_function_name(GearmanTask $obj): false|string {}
+function gearman_task_unique(GearmanTask $obj): false|string {}
+function gearman_task_job_handle(GearmanTask $obj): false|string {}
+function gearman_task_is_known(GearmanTask $obj): bool {}
+function gearman_task_is_running(GearmanTask $obj): bool {}
+function gearman_task_numerator(GearmanTask $obj): false|int {}
+function gearman_task_denominator(GearmanTask $obj): false|int {}
+function gearman_task_data(GearmanTask $obj): false|string {}
 function gearman_task_data_size(GearmanTask $obj): int|false {}
 function gearman_task_send_workload(GearmanTask $obj, string $data): int|false {}
-function gearman_task_recv_data(GearmanTask $obj, int $data_len): null|false|array {}
+function gearman_task_recv_data(GearmanTask $obj, int $data_len): false|array {}
 
 class GearmanWorker {
     public function __construct() {}
     public function __destruct() {}
 
     /** @alias gearman_worker_return_code */
-    public function returnCode(): ?int {}
+    public function returnCode(): int {}
 
     /** @alias gearman_worker_error */
     public function error(): string|false {}
 
     /** @alias gearman_worker_errno */
-    public function getErrno(): int|false {}
+    public function getErrno(): int {}
 
     /** @alias gearman_worker_options */
-    public function options(): ?int {}
+    public function options(): int {}
 
     /** @alias gearman_worker_set_options */
-    public function setOptions(int $option): ?bool {}
+    public function setOptions(int $option): true {}
 
     /** @alias gearman_worker_add_options */
-    public function addOptions(int $option): ?bool {}
+    public function addOptions(int $option): true {}
 
     /** @alias gearman_worker_remove_options */
-    public function removeOptions(int $option): ?bool {}
+    public function removeOptions(int $option): true {}
 
     /** @alias gearman_worker_timeout */
-    public function timeout(): ?int {}
+    public function timeout(): int {}
 
     /** @alias gearman_worker_set_timeout */
-    public function setTimeout(int $timeout): bool {}
+    public function setTimeout(int $timeout): true {}
 
     /** @alias gearman_worker_set_id */
     public function setId(string $id): bool {}
@@ -367,15 +367,15 @@ class GearmanWorker {
     public function enableExceptionHandler(): bool {}
 }
 
-function gearman_worker_return_code(GearmanWorker $obj): ?int {}
+function gearman_worker_return_code(GearmanWorker $obj): int {}
 function gearman_worker_error(GearmanWorker $obj): string|false {}
-function gearman_worker_errno(GearmanWorker $obj): int|false {}
-function gearman_worker_options(GearmanWorker $obj): ?int {}
-function gearman_worker_set_options(GearmanWorker $obj, int $option): ?bool {}
-function gearman_worker_add_options(GearmanWorker $obj, int $option): ?bool {}
-function gearman_worker_remove_options(GearmanWorker $obj, int $option): ?bool {}
-function gearman_worker_timeout(GearmanWorker $obj): ?int {}
-function gearman_worker_set_timeout(GearmanWorker $obj, int $timeout): bool {}
+function gearman_worker_errno(GearmanWorker $obj): int {}
+function gearman_worker_options(GearmanWorker $obj): int {}
+function gearman_worker_set_options(GearmanWorker $obj, int $option): true {}
+function gearman_worker_add_options(GearmanWorker $obj, int $option): true {}
+function gearman_worker_remove_options(GearmanWorker $obj, int $option): true {}
+function gearman_worker_timeout(GearmanWorker $obj): int {}
+function gearman_worker_set_timeout(GearmanWorker $obj, int $timeout): true {}
 function gearman_worker_set_id(GearmanWorker $obj, string $id): bool {}
 function gearman_worker_add_server(GearmanWorker $obj, string $host = null, int $port = 0, bool $setupExceptionHandler = true): bool {}
 function gearman_worker_add_servers(GearmanWorker $obj, string $servers = null, bool $setupExceptionHandler = true): bool {}

--- a/gearman.stub.php
+++ b/gearman.stub.php
@@ -14,16 +14,16 @@ class GearmanClient {
     public function __destruct() {}
 
     /** @alias gearman_client_return_code */
-    public function returnCode(): int {}
+    public function returnCode(): ?int {}
 
     /** @alias gearman_client_error */
-    public function error(): string|false {}
+    public function error(): string|false|null {}
 
     /** @alias gearman_client_get_errno */
-    public function getErrno(): int {}
+    public function getErrno(): ?int {}
 
     /** @alias gearman_client_options */
-    public function options(): int {}
+    public function options(): ?int {}
 
     /** @alias gearman_client_set_options */
     public function setOptions(int $option): bool {}
@@ -35,7 +35,7 @@ class GearmanClient {
     public function removeOptions(int $option): bool {}
 
     /** @alias gearman_client_timeout */
-    public function timeout(): int {}
+    public function timeout(): ?int {}
 
     /** @alias gearman_client_set_timeout */
     public function setTimeout(int $timeout): bool {}
@@ -104,7 +104,7 @@ class GearmanClient {
     public function runTasks(): bool {}
 
     /** @alias gearman_client_add_task_status */
-    public function addTaskStatus (string $job_handle, mixed $context = null): GearmanTask {}
+    public function addTaskStatus (string $job_handle, mixed $context = null): GearmanTask|false {}
 
     /** @alias gearman_client_set_workload_callback */
     public function setWorkloadCallback(callable $function): bool {}
@@ -174,7 +174,7 @@ function gearman_client_add_task_background(GearmanClient $obj, string $function
 function gearman_client_add_task_high_background(GearmanClient $obj, string $function_name, string|int|float $workload, mixed $context = null, ?string $unique_key = null): GearmanTask|false {}
 function gearman_client_add_task_low_background(GearmanClient $obj, string $function_name, string|int|float $workload, mixed $context = null, ?string $unique_key = null): GearmanTask|false {}
 function gearman_client_run_tasks(GearmanClient $obj): bool {}
-function gearman_client_add_task_status(GearmanClient $obj, string $job_handle, mixed $context = null): GearmanTask {}
+function gearman_client_add_task_status(GearmanClient $obj, string $job_handle, mixed $context = null): GearmanTask|false {}
 function gearman_client_set_workload_callback(GearmanClient $obj, callable $function): bool {}
 function gearman_client_set_created_callback(GearmanClient $obj, callable $function): bool {}
 function gearman_client_set_data_callback(GearmanClient $obj, callable $function): bool {}
@@ -253,25 +253,25 @@ class GearmanTask {
     public function returnCode(): int {}
 
     /** @alias gearman_task_function_name */
-    public function functionName(): bool|string {}
+    public function functionName(): null|false|string {}
 
     /** @alias gearman_task_unique */
     public function unique(): bool|string {}
 
     /** @alias gearman_task_job_handle */
-    public function jobHandle(): bool|string {}
+    public function jobHandle(): null|false|string {}
 
     /** @alias gearman_task_is_known */
-    public function isKnown(): bool {}
+    public function isKnown(): ?bool {}
 
     /** @alias gearman_task_is_running */
-    public function isRunning(): bool {}
+    public function isRunning(): ?bool {}
 
     /** @alias gearman_task_numerator */
-    public function taskNumerator(): bool|int {}
+    public function taskNumerator(): ?bool|int {}
 
     /** @alias gearman_task_denominator */
-    public function taskDenominator(): bool|int {}
+    public function taskDenominator(): ?bool|int {}
 
     /** @alias gearman_task_data */
     public function data(): bool|string {}
@@ -283,7 +283,7 @@ class GearmanTask {
     public function sendWorkload(string $data): int|false {}
 
     /** @alias gearman_task_recv_data */
-    public function recvData(int $data_len): bool|array {}
+    public function recvData(int $data_len): null|false|array {}
 }
 
 function gearman_task_return_code(GearmanTask $obj): ?int {}
@@ -297,7 +297,7 @@ function gearman_task_denominator(GearmanTask $obj): null|bool|int {}
 function gearman_task_data(GearmanTask $obj): null|bool|string {}
 function gearman_task_data_size(GearmanTask $obj): int|false {}
 function gearman_task_send_workload(GearmanTask $obj, string $data): int|false {}
-function gearman_task_recv_data(GearmanTask $obj, int $data_len): bool|array {}
+function gearman_task_recv_data(GearmanTask $obj, int $data_len): null|false|array {}
 
 class GearmanWorker {
     public function __construct() {}

--- a/php_gearman.c
+++ b/php_gearman.c
@@ -70,7 +70,7 @@ PHP_FUNCTION(gearman_bugreport) {
 }
 /* }}} */
 
-/* {{{ proto string gearman_verbose_name(constant verbose)
+/* {{{ proto ?string gearman_verbose_name(constant verbose)
    Returns string with the name of the given verbose level */
 PHP_FUNCTION(gearman_verbose_name) {
 	zend_long verbose;

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -36,7 +36,7 @@ static void gearman_client_ctor(INTERNAL_FUNCTION_PARAMETERS) {
         gearman_client_set_task_context_free_fn(&(client->client), _php_task_free);
 }
 
-/* {{{ proto object gearman_client_create()
+/* {{{ proto false|object gearman_client_create()
    Returns a GearmanClient object */
 PHP_FUNCTION(gearman_client_create) {
         if (object_init_ex(return_value, gearman_client_ce) != SUCCESS) {
@@ -113,7 +113,7 @@ void gearman_client_free_obj(zend_object *object) {
         zend_object_std_dtor(&intern->std);
 }
 
-/* {{{ proto int gearman_client_return_code()
+/* {{{ proto ?int gearman_client_return_code()
    get last gearman_return_t */
 PHP_FUNCTION(gearman_client_return_code)
 {
@@ -129,7 +129,7 @@ PHP_FUNCTION(gearman_client_return_code)
 }
 /* }}} */
 
-/* {{{ proto string gearman_client_error()
+/* {{{ proto null|false|string gearman_client_error()
    Return an error string for the last error encountered. */
 PHP_FUNCTION(gearman_client_error) {
         char *error = NULL;
@@ -149,7 +149,7 @@ PHP_FUNCTION(gearman_client_error) {
 }
 /* }}} */
 
-/* {{{ proto int gearman_client_get_errno()
+/* {{{ proto ?int gearman_client_get_errno()
    Value of errno in the case of a GEARMAN_ERRNO return value. */
 PHP_FUNCTION(gearman_client_get_errno) {
         gearman_client_obj *obj;
@@ -164,7 +164,7 @@ PHP_FUNCTION(gearman_client_get_errno) {
 }
 /* }}} */
 
-/* {{{ proto int gearman_client_options()
+/* {{{ proto ?int gearman_client_options()
    Get options for a client structure. */
 PHP_FUNCTION(gearman_client_options) {
         gearman_client_obj *obj;
@@ -179,7 +179,7 @@ PHP_FUNCTION(gearman_client_options) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_client_set_options(constant option)
+/* {{{ proto bool gearman_client_set_options(constant option)
    Set options for a client structure.
    NOTE: this is deprecated in gearmand */
 PHP_FUNCTION(gearman_client_set_options) {
@@ -198,7 +198,7 @@ PHP_FUNCTION(gearman_client_set_options) {
 }
 /* }}} */
 
-/* {{{ proto void GearmanClient::addOptions(constant option)
+/* {{{ proto bool GearmanClient::addOptions(constant option)
    Set options for a client structure. */
 PHP_FUNCTION(gearman_client_add_options) {
         zend_long options;
@@ -216,7 +216,7 @@ PHP_FUNCTION(gearman_client_add_options) {
 }
 /* }}} */
 
-/* {{{ proto void GearmanClient::removeOptions(constant option)
+/* {{{ proto bool GearmanClient::removeOptions(constant option)
    Set options for a client structure. */
 PHP_FUNCTION(gearman_client_remove_options) {
         zend_long options;
@@ -234,7 +234,7 @@ PHP_FUNCTION(gearman_client_remove_options) {
 }
 /* }}} */
 
-/* {{{ proto int GearmanClient::timeout()
+/* {{{ proto ?int GearmanClient::timeout()
    Get current socket I/O activity timeout value */
 PHP_FUNCTION(gearman_client_timeout) {
         gearman_client_obj *obj;
@@ -249,7 +249,7 @@ PHP_FUNCTION(gearman_client_timeout) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_client_set_timeout(object, constant timeout)
+/* {{{ proto bool gearman_client_set_timeout(object, constant timeout)
    Set timeout for a client structure. */
 PHP_FUNCTION(gearman_client_set_timeout) {
         zend_long timeout;
@@ -365,7 +365,7 @@ PHP_FUNCTION(gearman_client_wait) {
 }
 /* }}} */
 
-/* {{{ proto object gearman_client_do_work_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
+/* {{{ proto string gearman_client_do_work_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
    Run a task, high/normal/low dependent upon do_work_func */
 static void gearman_client_do_work_handler(void* (*do_work_func)(
                                                                 gearman_client_st *client,
@@ -443,7 +443,7 @@ PHP_FUNCTION(gearman_client_do_low) {
 }
 /* }}} */
 
-/* {{{ proto object gearman_client_do_background_work_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
+/* {{{ proto string gearman_client_do_background_work_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
    Run a task in the background, high/normal/low dependent upon do_work_func */
 static void gearman_client_do_background_work_handler(gearman_return_t (*do_background_work_func)(
                                                                 gearman_client_st *client,
@@ -651,7 +651,7 @@ PHP_FUNCTION(gearman_client_ping) {
 }
 /* }}} */
 
-/* {{{ proto object gearman_client_add_task_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
+/* {{{ proto false|object gearman_client_add_task_handler(void *add_task_func, object client, string function, zval workload [, string unique ])
    Add a task to be run in parallel, background or not, high/normal/low dependent upon add_task_func. */
 static void gearman_client_add_task_handler(gearman_task_st* (*add_task_func)(
                                                                 gearman_client_st *client,
@@ -739,42 +739,42 @@ static void gearman_client_add_task_handler(gearman_task_st* (*add_task_func)(
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTask(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTask(string function, zval workload [, string unique ])
    Add a task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task) {
         gearman_client_add_task_handler(gearman_client_add_task, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTaskHigh(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTaskHigh(string function, zval workload [, string unique ])
    Add a high priority task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task_high) {
         gearman_client_add_task_handler(gearman_client_add_task_high, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTaskLow(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTaskLow(string function, zval workload [, string unique ])
    Add a low priority task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task_low) {
         gearman_client_add_task_handler(gearman_client_add_task_low, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTaskBackground(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTaskBackground(string function, zval workload [, string unique ])
    Add a background task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task_background) {
         gearman_client_add_task_handler(gearman_client_add_task_background, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTaskHighBackground(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTaskHighBackground(string function, zval workload [, string unique ])
    Add a high priority background task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task_high_background) {
         gearman_client_add_task_handler(gearman_client_add_task_high_background, INTERNAL_FUNCTION_PARAM_PASSTHRU);
 }
 /* }}} */
 
-/* {{{ proto object GearmanClient::addTaskLowBackground(string function, zval workload [, string unique ])
+/* {{{ proto false|object GearmanClient::addTaskLowBackground(string function, zval workload [, string unique ])
    Add a low priority background task to be run in parallel. */
 PHP_FUNCTION(gearman_client_add_task_low_background) {
         gearman_client_add_task_handler(gearman_client_add_task_low_background, INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -807,7 +807,7 @@ PHP_FUNCTION(gearman_client_run_tasks) {
 /* this function is used to request status information from the gearmand
  * server. it will then call your predefined status callback, passing
  * zdata/context to it */
-/* {{{ proto object gearman_client_add_task_status(object client, string job_handle [, zval data])
+/* {{{ proto false|object gearman_client_add_task_status(object client, string job_handle [, zval data])
    Add task to get the status for a backgound task in parallel. */
 PHP_FUNCTION(gearman_client_add_task_status) {
         zval *zdata = NULL;

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -113,7 +113,7 @@ void gearman_client_free_obj(zend_object *object) {
         zend_object_std_dtor(&intern->std);
 }
 
-/* {{{ proto ?int gearman_client_return_code()
+/* {{{ proto int gearman_client_return_code()
    get last gearman_return_t */
 PHP_FUNCTION(gearman_client_return_code)
 {
@@ -129,7 +129,7 @@ PHP_FUNCTION(gearman_client_return_code)
 }
 /* }}} */
 
-/* {{{ proto null|false|string gearman_client_error()
+/* {{{ proto false|string gearman_client_error()
    Return an error string for the last error encountered. */
 PHP_FUNCTION(gearman_client_error) {
         char *error = NULL;
@@ -149,7 +149,7 @@ PHP_FUNCTION(gearman_client_error) {
 }
 /* }}} */
 
-/* {{{ proto ?int gearman_client_get_errno()
+/* {{{ proto int gearman_client_get_errno()
    Value of errno in the case of a GEARMAN_ERRNO return value. */
 PHP_FUNCTION(gearman_client_get_errno) {
         gearman_client_obj *obj;
@@ -164,7 +164,7 @@ PHP_FUNCTION(gearman_client_get_errno) {
 }
 /* }}} */
 
-/* {{{ proto ?int gearman_client_options()
+/* {{{ proto int gearman_client_options()
    Get options for a client structure. */
 PHP_FUNCTION(gearman_client_options) {
         gearman_client_obj *obj;
@@ -234,7 +234,7 @@ PHP_FUNCTION(gearman_client_remove_options) {
 }
 /* }}} */
 
-/* {{{ proto ?int GearmanClient::timeout()
+/* {{{ proto int GearmanClient::timeout()
    Get current socket I/O activity timeout value */
 PHP_FUNCTION(gearman_client_timeout) {
         gearman_client_obj *obj;

--- a/php_gearman_job.c
+++ b/php_gearman_job.c
@@ -42,7 +42,7 @@ zend_object *gearman_job_obj_new(zend_class_entry *ce) {
         return &intern->std;
 }
 
-/* {{{ proto ?int gearman_job_return_code()
+/* {{{ proto int gearman_job_return_code()
    get last gearman_return_t */
 PHP_FUNCTION(gearman_job_return_code) {
         gearman_job_obj *obj;
@@ -57,7 +57,7 @@ PHP_FUNCTION(gearman_job_return_code) {
 }
 /* }}} */
 
-/* {{{ proto ?bool gearman_job_set_return(int gearman_return_t)
+/* {{{ proto bool gearman_job_set_return(int gearman_return_t)
    This function will set a return value of a job */
 PHP_FUNCTION(gearman_job_set_return) {
         zval *zobj;
@@ -83,7 +83,7 @@ PHP_FUNCTION(gearman_job_set_return) {
 }
 /* }}} */
 
-/* {{{ proto ?bool gearman_job_send_data(object job, string data)
+/* {{{ proto bool gearman_job_send_data(object job, string data)
    Send data for a running job. */
 PHP_FUNCTION(gearman_job_send_data) {
         zval *zobj;
@@ -240,7 +240,7 @@ PHP_FUNCTION(gearman_job_send_fail) {
 }
 /* }}} */
 
-/* {{{ proto ?bool|string gearman_job_handle(object job)
+/* {{{ proto false|string gearman_job_handle(object job)
    Return job handle. */
 PHP_FUNCTION(gearman_job_handle) {
 	zval *zobj;
@@ -260,7 +260,7 @@ PHP_FUNCTION(gearman_job_handle) {
 }
 /* }}} */
 
-/* {{{ proto ?bool|string gearman_job_function_name(object job)
+/* {{{ proto false|string gearman_job_function_name(object job)
    Return the function name associated with a job. */
 PHP_FUNCTION(gearman_job_function_name) {
 	zval *zobj;
@@ -280,7 +280,7 @@ PHP_FUNCTION(gearman_job_function_name) {
 }
 /* }}} */
 
-/* {{{ proto ?bool|string gearman_job_unique(object job)
+/* {{{ proto false|string gearman_job_unique(object job)
    Get the unique ID associated with a job. */
 PHP_FUNCTION(gearman_job_unique) {
 	zval *zobj;
@@ -300,7 +300,7 @@ PHP_FUNCTION(gearman_job_unique) {
 }
 /* }}} */
 
-/* {{{ proto ?string gearman_job_workload(object job)
+/* {{{ proto string gearman_job_workload(object job)
    Returns the workload for a job. */
 PHP_FUNCTION(gearman_job_workload) {
 	zval *zobj;
@@ -320,7 +320,7 @@ PHP_FUNCTION(gearman_job_workload) {
 }
 /* }}} */
 
-/* {{{ proto ?int gearman_job_workload_size(object job)
+/* {{{ proto int gearman_job_workload_size(object job)
    Returns size of the workload for a job. */
 PHP_FUNCTION(gearman_job_workload_size) {
 	zval *zobj;

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -155,7 +155,7 @@ PHP_FUNCTION(gearman_task_return_code) {
 }
 /* }}} */
 
-/* {{{ proto ?bool|string gearman_task_function_name(object task)
+/* {{{ proto null|false|string gearman_task_function_name(object task)
    Returns function name associated with a task. */
 PHP_FUNCTION(gearman_task_function_name) {
         zval *zobj;
@@ -189,7 +189,7 @@ PHP_FUNCTION(gearman_task_unique) {
 }
 /* }}} */
 
-/* {{{ proto string gearman_task_job_handle(object task)
+/* {{{ proto null|false|string gearman_task_job_handle(object task)
    Returns job handle for a task. */
 PHP_FUNCTION(gearman_task_job_handle) {
         zval *zobj;
@@ -205,7 +205,7 @@ PHP_FUNCTION(gearman_task_job_handle) {
         RETURN_FALSE;
 }
 /* }}} */
-/* {{{ proto bool gearman_task_is_known(object task)
+/* {{{ proto ?bool gearman_task_is_known(object task)
    Get status on whether a task is known or not */
 PHP_FUNCTION(gearman_task_is_known) {
 	zval *zobj;
@@ -223,7 +223,7 @@ PHP_FUNCTION(gearman_task_is_known) {
 /* }}} */
 
 
-/* {{{ proto bool gearman_task_is_running(object task)
+/* {{{ proto ?bool gearman_task_is_running(object task)
    Get status on whether a task is running or not */
 PHP_FUNCTION(gearman_task_is_running) {
 	zval *zobj;
@@ -241,7 +241,7 @@ PHP_FUNCTION(gearman_task_is_running) {
 /* }}} */
 
 
-/* {{{ proto int gearman_task_numerator(object task)
+/* {{{ proto ?bool|int gearman_task_numerator(object task)
    Returns the numerator of percentage complete for a task. */
 PHP_FUNCTION(gearman_task_numerator) {
 	zval *zobj;
@@ -259,7 +259,7 @@ PHP_FUNCTION(gearman_task_numerator) {
 /* }}} */
 
 
-/* {{{ proto int gearman_task_denominator(object task)
+/* {{{ proto ?bool|int gearman_task_denominator(object task)
    Returns the denominator of percentage complete for a task. */
 PHP_FUNCTION(gearman_task_denominator) {
 	zval *zobj;
@@ -275,7 +275,7 @@ PHP_FUNCTION(gearman_task_denominator) {
 	RETURN_FALSE;
 }
 /* }}} */
-/* {{{ proto string gearman_task_data(object task)
+/* {{{ proto null|false|string gearman_task_data(object task)
    Get data being returned for a task. */
 PHP_FUNCTION(gearman_task_data) {
 	zval *zobj;
@@ -300,7 +300,7 @@ PHP_FUNCTION(gearman_task_data) {
 /* }}} */
 
 
-/* {{{ proto int gearman_task_data_size(object task)
+/* {{{ proto false|int gearman_task_data_size(object task)
    Get data size being returned for a task. */
 PHP_FUNCTION(gearman_task_data_size) {
 	zval *zobj;
@@ -318,7 +318,7 @@ PHP_FUNCTION(gearman_task_data_size) {
 /* }}} */
 
 
-/* {{{ proto int gearman_task_send_workload(object task, string data)
+/* {{{ proto false|int gearman_task_send_workload(object task, string data)
    NOT-TESTED Send packet data for a task. */
 PHP_FUNCTION(gearman_task_send_workload) {
 	zval *zobj;
@@ -351,7 +351,7 @@ PHP_FUNCTION(gearman_task_send_workload) {
 /* }}} */
 
 
-/* {{{ proto array gearman_task_recv_data(object task, long buffer_size)
+/* {{{ proto null|false|array gearman_task_recv_data(object task, long buffer_size)
    NOT-TESTED Read work or result data into a buffer for a task. */
 PHP_FUNCTION(gearman_task_recv_data) {
 	zval *zobj;

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -140,7 +140,7 @@ void gearman_task_free_obj(zend_object *object) {
         zend_object_std_dtor(&intern->std);
 }
 
-/* {{{ proto ?int gearman_task_return_code()
+/* {{{ proto int gearman_task_return_code()
    get last gearman_return_t */
 PHP_FUNCTION(gearman_task_return_code) {
         zval *zobj;
@@ -155,7 +155,7 @@ PHP_FUNCTION(gearman_task_return_code) {
 }
 /* }}} */
 
-/* {{{ proto null|false|string gearman_task_function_name(object task)
+/* {{{ proto false|string gearman_task_function_name(object task)
    Returns function name associated with a task. */
 PHP_FUNCTION(gearman_task_function_name) {
         zval *zobj;
@@ -172,7 +172,7 @@ PHP_FUNCTION(gearman_task_function_name) {
 }
 /* }}} */
 
-/* {{{ proto ?bool|string gearman_task_unique(object task)
+/* {{{ proto false|string gearman_task_unique(object task)
    Returns unique identifier for a task. */
 PHP_FUNCTION(gearman_task_unique) {
         zval *zobj;
@@ -189,7 +189,7 @@ PHP_FUNCTION(gearman_task_unique) {
 }
 /* }}} */
 
-/* {{{ proto null|false|string gearman_task_job_handle(object task)
+/* {{{ proto false|string gearman_task_job_handle(object task)
    Returns job handle for a task. */
 PHP_FUNCTION(gearman_task_job_handle) {
         zval *zobj;
@@ -205,7 +205,7 @@ PHP_FUNCTION(gearman_task_job_handle) {
         RETURN_FALSE;
 }
 /* }}} */
-/* {{{ proto ?bool gearman_task_is_known(object task)
+/* {{{ proto bool gearman_task_is_known(object task)
    Get status on whether a task is known or not */
 PHP_FUNCTION(gearman_task_is_known) {
 	zval *zobj;
@@ -223,7 +223,7 @@ PHP_FUNCTION(gearman_task_is_known) {
 /* }}} */
 
 
-/* {{{ proto ?bool gearman_task_is_running(object task)
+/* {{{ proto bool gearman_task_is_running(object task)
    Get status on whether a task is running or not */
 PHP_FUNCTION(gearman_task_is_running) {
 	zval *zobj;
@@ -241,7 +241,7 @@ PHP_FUNCTION(gearman_task_is_running) {
 /* }}} */
 
 
-/* {{{ proto ?bool|int gearman_task_numerator(object task)
+/* {{{ proto false|int gearman_task_numerator(object task)
    Returns the numerator of percentage complete for a task. */
 PHP_FUNCTION(gearman_task_numerator) {
 	zval *zobj;
@@ -259,7 +259,7 @@ PHP_FUNCTION(gearman_task_numerator) {
 /* }}} */
 
 
-/* {{{ proto ?bool|int gearman_task_denominator(object task)
+/* {{{ proto false|int gearman_task_denominator(object task)
    Returns the denominator of percentage complete for a task. */
 PHP_FUNCTION(gearman_task_denominator) {
 	zval *zobj;
@@ -275,7 +275,7 @@ PHP_FUNCTION(gearman_task_denominator) {
 	RETURN_FALSE;
 }
 /* }}} */
-/* {{{ proto null|false|string gearman_task_data(object task)
+/* {{{ proto false|string gearman_task_data(object task)
    Get data being returned for a task. */
 PHP_FUNCTION(gearman_task_data) {
 	zval *zobj;
@@ -351,7 +351,7 @@ PHP_FUNCTION(gearman_task_send_workload) {
 /* }}} */
 
 
-/* {{{ proto null|false|array gearman_task_recv_data(object task, long buffer_size)
+/* {{{ proto false|array gearman_task_recv_data(object task, long buffer_size)
    NOT-TESTED Read work or result data into a buffer for a task. */
 PHP_FUNCTION(gearman_task_recv_data) {
 	zval *zobj;

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -98,7 +98,7 @@ zend_object *gearman_worker_obj_new(zend_class_entry *ce) {
 	return &intern->std;
 }
 
-/* {{{ proto ?int gearman_worker_return_code()
+/* {{{ proto int gearman_worker_return_code()
    get last gearman_return_t */
 PHP_FUNCTION(gearman_worker_return_code) {
         gearman_worker_obj *obj;
@@ -133,7 +133,7 @@ PHP_FUNCTION(gearman_worker_error) {
 }
 /* }}} */
 
-/* {{{ proto int|false gearman_worker_errno(object worker)
+/* {{{ proto int gearman_worker_errno(object worker)
    Value of errno in the case of a GEARMAN_ERRNO return value. */
 PHP_FUNCTION(gearman_worker_errno) {
         zval *zobj;
@@ -148,7 +148,7 @@ PHP_FUNCTION(gearman_worker_errno) {
 }
 /* }}} */
 
-/* {{{ proto ?int gearman_worker_options(object worker)
+/* {{{ proto int gearman_worker_options(object worker)
    Get options for a worker structure. */
 PHP_FUNCTION(gearman_worker_options) {
         zval *zobj;
@@ -163,7 +163,7 @@ PHP_FUNCTION(gearman_worker_options) {
 }
 /* }}} */
 
-/* {{{ proto null|true gearman_worker_set_options(object worker, constant option)
+/* {{{ proto true gearman_worker_set_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_options) {
         zval *zobj;
@@ -180,7 +180,7 @@ PHP_FUNCTION(gearman_worker_set_options) {
 }
 /* }}} */
 
-/* {{{ proto null|true gearman_worker_add_options(object worker, constant option)
+/* {{{ proto true gearman_worker_add_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_add_options) {
         zval *zobj;
@@ -197,7 +197,7 @@ PHP_FUNCTION(gearman_worker_add_options) {
 }
 /* }}} */
 
-/* {{{ proto null|true gearman_worker_remove_options(object worker, constant option)
+/* {{{ proto true gearman_worker_remove_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_remove_options) {
         zval *zobj;
@@ -214,7 +214,7 @@ PHP_FUNCTION(gearman_worker_remove_options) {
 }
 /* }}} */
 
-/* {{{ proto ?int gearman_worker_timeout(object worker)
+/* {{{ proto int gearman_worker_timeout(object worker)
    Get timeout for a worker structure. */
 PHP_FUNCTION(gearman_worker_timeout) {
         zval *zobj;
@@ -229,7 +229,7 @@ PHP_FUNCTION(gearman_worker_timeout) {
 }
 /* }}} */
 
-/* {{{ proto bool gearman_worker_set_timeout(object worker, constant timeout)
+/* {{{ proto true gearman_worker_set_timeout(object worker, constant timeout)
    Set timeout for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_timeout) {
         zval *zobj;

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -148,7 +148,7 @@ PHP_FUNCTION(gearman_worker_errno) {
 }
 /* }}} */
 
-/* {{{ proto int gearman_worker_options(object worker)
+/* {{{ proto ?int gearman_worker_options(object worker)
    Get options for a worker structure. */
 PHP_FUNCTION(gearman_worker_options) {
         zval *zobj;
@@ -163,7 +163,7 @@ PHP_FUNCTION(gearman_worker_options) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_worker_set_options(object worker, constant option)
+/* {{{ proto null|true gearman_worker_set_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_options) {
         zval *zobj;
@@ -180,7 +180,7 @@ PHP_FUNCTION(gearman_worker_set_options) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_worker_add_options(object worker, constant option)
+/* {{{ proto null|true gearman_worker_add_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_add_options) {
         zval *zobj;
@@ -197,7 +197,7 @@ PHP_FUNCTION(gearman_worker_add_options) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_worker_remove_options(object worker, constant option)
+/* {{{ proto null|true gearman_worker_remove_options(object worker, constant option)
    Set options for a worker structure. */
 PHP_FUNCTION(gearman_worker_remove_options) {
         zval *zobj;
@@ -214,7 +214,7 @@ PHP_FUNCTION(gearman_worker_remove_options) {
 }
 /* }}} */
 
-/* {{{ proto int gearman_worker_timeout(object worker)
+/* {{{ proto ?int gearman_worker_timeout(object worker)
    Get timeout for a worker structure. */
 PHP_FUNCTION(gearman_worker_timeout) {
         zval *zobj;
@@ -229,7 +229,7 @@ PHP_FUNCTION(gearman_worker_timeout) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_worker_set_timeout(object worker, constant timeout)
+/* {{{ proto bool gearman_worker_set_timeout(object worker, constant timeout)
    Set timeout for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_timeout) {
         zval *zobj;
@@ -246,7 +246,7 @@ PHP_FUNCTION(gearman_worker_set_timeout) {
 }
 /* }}} */
 
-/* {{{ proto void gearman_worker_set_id(object worker, string id)
+/* {{{ proto bool gearman_worker_set_id(object worker, string id)
    Set id for a worker structure. */
 PHP_FUNCTION(gearman_worker_set_id) {
         zval *zobj;
@@ -440,7 +440,7 @@ PHP_FUNCTION(gearman_worker_unregister_all) {
 }
 /* }}} */
 
-/* {{{ proto object gearman_worker_grab_job(obect worker)
+/* {{{ proto false|object gearman_worker_grab_job(obect worker)
    Get a job from one of the job servers.
    Note: EXPERIMENTAL - This is undocumented on php.net and needs a test*/
 PHP_FUNCTION(gearman_worker_grab_job) {
@@ -627,7 +627,7 @@ PHP_FUNCTION(gearman_worker_add_function) {
 }
 /* }}} */
 
-/* {{{ proto int gearman_worker_work(object worker)
+/* {{{ proto bool gearman_worker_work(object worker)
 	Wait for a job and call the appropriate callback function when it gets one. */
 PHP_FUNCTION(gearman_worker_work) {
 	zval *zobj = NULL;


### PR DESCRIPTION
I have noticed, that some return types in the `proto` comments and in gearman.stub.php do not match with the actual return statements and changed the comments accordingly. I hope, I filled in a valid syntax. `|` and `?` seem to be allowed and if constant values like `true`, `false` and `null` are also allowed, everything should be fine.

To test if the library still works, I basically ran all the commands from the readme:
*  `phpize`
* `./configure`
* `make`
* `make test` with all tests passed
* `make install`
* `php examples/reverse_worker.php`
* `php examples/reverse_client.php`

Everything ran successfully.

Next I will do a PR for the manual pages for php.net.