### PR TITLE
fix: gearman_client_021.phpt - test failing when building debian package

### DIFF
--- a/tests/gearman_client_021.phpt
+++ b/tests/gearman_client_021.phpt
@@ -1,7 +1,9 @@
 --TEST--
 GearmanClient::enableExceptionHandler(),gearman_client_enable_exception_handler()
 --SKIPIF--
-<?php if (!extension_loaded("gearman")) print "skip"; ?>
+<?php if (!extension_loaded("gearman")) print "skip";
+require_once('skipifconnect.inc');
+?>
 --FILE--
 <?php 
 


### PR DESCRIPTION
Fixes a failure when building the Debian package:

```
TEST 23/65 [tests/gearman_client_021.phpt]
FAIL GearmanClient::enableExceptionHandler(),gearman_client_enable_exception_handler() [tests/gearman_client_021.phpt]
```

No further verbose information is given about the failure.

The other `GearmanClient` tests that attempt to `addServers()` have the changed code at the top of the test to [skip it when there is not a connection available](https://github.com/php/pecl-networking-gearman/blob/master/tests/skipifconnect.inc#L9) aka when there is no queue server actually running.

ie:
https://github.com/php/pecl-networking-gearman/blob/master/tests/gearman_client_020.phpt#L4-L6

https://github.com/php/pecl-networking-gearman/blob/master/tests/gearman_client_019.phpt#L4-L6

This change will allow all tests to pass when packaging and building a .deb.

**Note: I'm unsure if this should be considered a release and therefore did not include a ChangeLog update or version bump but happy to add if desired.**

  
