### PR TITLE
Allow PHP 8.4 & prepare release files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 2.1.3
+-------------
+- Bump max PHP version so pecl will install for PHP 8.4
+
 Version 2.1.2
 -------------
 - Bump max PHP version so pecl will install for PHP 8.2 and 8.3 as well

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
   <email>hradtke@php.net</email>
   <active>yes</active>
  </lead>
- <date>2024-04-04</date>
+ <date>2025-01-07</date>
  <time>22:00:00</time>
  <version>
-  <release>2.1.2</release>
-  <api>2.1.2</api>
+  <release>2.1.3</release>
+  <api>2.1.3</api>
  </version>
  <stability>
   <release>stable</release>
@@ -139,7 +139,7 @@ PHP 8 is now supported
   <required>
    <php>
     <min>7.0.0</min>
-    <max>8.3.99</max>
+    <max>8.4.99</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>
@@ -150,6 +150,21 @@ PHP 8 is now supported
  <providesextension>gearman</providesextension>
  <extsrcrelease />
  <changelog>
+
+  <release>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <version>
+    <release>2.1.3</release>
+    <api>2.1.3</api>
+   </version>
+   <date>2025-01-07</date>
+   <notes>
+- Bump max PHP version to support PHP 8.4
+   </notes>
+  </release>
 
   <release>
    <stability>

--- a/php_gearman.h
+++ b/php_gearman.h
@@ -24,7 +24,7 @@
 #include <libgearman-1.0/status.h>
 
 /* module version */
-#define PHP_GEARMAN_VERSION "2.1.2"
+#define PHP_GEARMAN_VERSION "2.1.3"
 
 extern zend_module_entry gearman_module_entry;
 #define phpext_gearman_ptr &gearman_module_entry


### PR DESCRIPTION
Hi,
If you only want the diff for `required.php.max` I can update the PR