### PR TITLE
use zend_ce_exception instead of zend_exception_get_default() for 8.5

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -121,7 +121,7 @@ PHP_MINIT_FUNCTION(gearman) {
 
 	/* XXX exception class */
 	INIT_CLASS_ENTRY(ce, "GearmanException", class_GearmanException_methods)
-	gearman_exception_ce = zend_register_internal_class_ex(&ce, zend_exception_get_default());
+	gearman_exception_ce = zend_register_internal_class_ex(&ce, zend_ce_exception);
 	gearman_exception_ce->ce_flags |= ZEND_ACC_FINAL;
 	zend_declare_property_long(gearman_exception_ce, "code", sizeof("code")-1, 0, ZEND_ACC_PUBLIC);
 


### PR DESCRIPTION
* `zend_ce_exception` available since 7.0
* `zend_exception_get_default` removed in 8.5