### PR TITLE
Support PHP 8.6

### DIFF
--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -101,16 +101,16 @@ void gearman_client_free_obj(zend_object *object) {
         }
 
         // Clear Callbacks
-        zval_dtor(&intern->zworkload_fn);
-        zval_dtor(&intern->zcreated_fn);
-        zval_dtor(&intern->zdata_fn);
-        zval_dtor(&intern->zwarning_fn);
-        zval_dtor(&intern->zstatus_fn);
-        zval_dtor(&intern->zcomplete_fn);
-        zval_dtor(&intern->zexception_fn);
-        zval_dtor(&intern->zfail_fn);
+        zval_ptr_dtor_nogc(&intern->zworkload_fn);
+        zval_ptr_dtor_nogc(&intern->zcreated_fn);
+        zval_ptr_dtor_nogc(&intern->zdata_fn);
+        zval_ptr_dtor_nogc(&intern->zwarning_fn);
+        zval_ptr_dtor_nogc(&intern->zstatus_fn);
+        zval_ptr_dtor_nogc(&intern->zcomplete_fn);
+        zval_ptr_dtor_nogc(&intern->zexception_fn);
+        zval_ptr_dtor_nogc(&intern->zfail_fn);
 
-        zval_dtor(&intern->task_list);
+        zval_ptr_dtor_nogc(&intern->task_list);
 
         zend_object_std_dtor(&intern->std);
 }
@@ -883,7 +883,7 @@ PHP_FUNCTION(gearman_client_set_workload_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zworkload_fn)) {
-		zval_dtor(&obj->zworkload_fn);
+		zval_ptr_dtor_nogc(&obj->zworkload_fn);
 	}
 
 	/* store the cb in client object */
@@ -922,7 +922,7 @@ PHP_FUNCTION(gearman_client_set_created_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zcreated_fn)) {
-		zval_dtor(&obj->zcreated_fn);
+		zval_ptr_dtor_nogc(&obj->zcreated_fn);
 	}
 
 	/* store the cb in client object */
@@ -961,7 +961,7 @@ PHP_FUNCTION(gearman_client_set_data_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zdata_fn)) {
-		zval_dtor(&obj->zdata_fn);
+		zval_ptr_dtor_nogc(&obj->zdata_fn);
 	}
 
 	/* store the cb in client object */
@@ -1000,7 +1000,7 @@ PHP_FUNCTION(gearman_client_set_warning_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zwarning_fn)) {
-		zval_dtor(&obj->zwarning_fn);
+		zval_ptr_dtor_nogc(&obj->zwarning_fn);
 	}
 
 	/* store the cb in client object */
@@ -1040,7 +1040,7 @@ PHP_FUNCTION(gearman_client_set_status_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zstatus_fn)) {
-		zval_dtor(&obj->zstatus_fn);
+		zval_ptr_dtor_nogc(&obj->zstatus_fn);
 	}
 
 	/* store the cb in client object */
@@ -1079,7 +1079,7 @@ PHP_FUNCTION(gearman_client_set_complete_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zcomplete_fn)) {
-		zval_dtor(&obj->zcomplete_fn);
+		zval_ptr_dtor_nogc(&obj->zcomplete_fn);
 	}
 
 	/* store the cb in client object */
@@ -1122,7 +1122,7 @@ PHP_FUNCTION(gearman_client_set_exception_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zexception_fn)) {
-		zval_dtor(&obj->zexception_fn);
+		zval_ptr_dtor_nogc(&obj->zexception_fn);
 	}
 
 	/* store the cb in client object */
@@ -1162,7 +1162,7 @@ PHP_FUNCTION(gearman_client_set_fail_callback) {
 
 	/* Defining callback again? Clean up old one first */
 	if (!Z_ISUNDEF(obj->zfail_fn)) {
-		zval_dtor(&obj->zfail_fn);
+		zval_ptr_dtor_nogc(&obj->zfail_fn);
 	}
 
 	/* store the cb in client object */
@@ -1188,21 +1188,21 @@ PHP_FUNCTION(gearman_client_clear_callbacks) {
 
         gearman_client_clear_fn(&obj->client);
 
-        zval_dtor(&obj->zworkload_fn);
+        zval_ptr_dtor_nogc(&obj->zworkload_fn);
         ZVAL_UNDEF(&obj->zworkload_fn);
-        zval_dtor(&obj->zcreated_fn);
+        zval_ptr_dtor_nogc(&obj->zcreated_fn);
         ZVAL_UNDEF(&obj->zcreated_fn);
-        zval_dtor(&obj->zdata_fn);
+        zval_ptr_dtor_nogc(&obj->zdata_fn);
         ZVAL_UNDEF(&obj->zdata_fn);
-        zval_dtor(&obj->zwarning_fn);
+        zval_ptr_dtor_nogc(&obj->zwarning_fn);
         ZVAL_UNDEF(&obj->zwarning_fn);
-        zval_dtor(&obj->zstatus_fn);
+        zval_ptr_dtor_nogc(&obj->zstatus_fn);
         ZVAL_UNDEF(&obj->zstatus_fn);
-        zval_dtor(&obj->zcomplete_fn);
+        zval_ptr_dtor_nogc(&obj->zcomplete_fn);
         ZVAL_UNDEF(&obj->zcomplete_fn);
-        zval_dtor(&obj->zexception_fn);
+        zval_ptr_dtor_nogc(&obj->zexception_fn);
         ZVAL_UNDEF(&obj->zexception_fn);
-        zval_dtor(&obj->zfail_fn);
+        zval_ptr_dtor_nogc(&obj->zfail_fn);
         ZVAL_UNDEF(&obj->zfail_fn);
 
         RETURN_TRUE;

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -133,9 +133,9 @@ void gearman_task_free_obj(zend_object *object) {
                 return;
         }
 
-        zval_dtor(&intern->zworkload);
-        zval_dtor(&intern->zdata);
-        zval_dtor(&intern->zclient);
+        zval_ptr_dtor_nogc(&intern->zworkload);
+        zval_ptr_dtor_nogc(&intern->zdata);
+        zval_ptr_dtor_nogc(&intern->zclient);
 
         zend_object_std_dtor(&intern->std);
 }

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -26,7 +26,7 @@ static void gearman_worker_ctor(INTERNAL_FUNCTION_PARAMETERS) {
 	worker = Z_GEARMAN_WORKER_P(return_value);
 
 	if (gearman_worker_create(&(worker->worker)) == NULL) {
-		zval_dtor(return_value);
+		zval_ptr_dtor_nogc(return_value);
 		GEARMAN_EXCEPTION("Memory allocation failure", 0);
 	}
 
@@ -65,7 +65,7 @@ void gearman_worker_free_obj(zend_object *object) {
                 intern->flags &= ~GEARMAN_WORKER_OBJ_CREATED;
         }
 
-        zval_dtor(&intern->cb_list);
+        zval_ptr_dtor_nogc(&intern->cb_list);
 
         zend_object_std_dtor(&intern->std);
 }
@@ -88,9 +88,9 @@ PHP_METHOD(GearmanWorker, __destruct) {
 
 static inline void cb_list_dtor(zval *zv) {
 	gearman_worker_cb_obj *worker_cb = Z_PTR_P(zv);
-	zval_dtor(&worker_cb->zname);
-	zval_dtor(&worker_cb->zdata);
-	zval_dtor(&worker_cb->zcall);
+	zval_ptr_dtor_nogc(&worker_cb->zname);
+	zval_ptr_dtor_nogc(&worker_cb->zdata);
+	zval_ptr_dtor_nogc(&worker_cb->zcall);
 	efree(worker_cb);
 }
 
@@ -471,7 +471,7 @@ PHP_FUNCTION(gearman_worker_grab_job) {
         if (obj->ret != GEARMAN_SUCCESS && obj->ret != GEARMAN_IO_WAIT) {
                 php_error_docref(NULL, E_WARNING, "%s",
                                                  gearman_worker_error(&(obj->worker)));
-                zval_dtor(return_value);
+                zval_ptr_dtor_nogc(return_value);
                 RETURN_FALSE;
         }
 
@@ -544,15 +544,15 @@ static void *_php_worker_function_callback(gearman_job_st *job,
                 }
                 result = estrndup(Z_STRVAL(retval), Z_STRLEN(retval));
                 *result_size = Z_STRLEN(retval);
-                zval_dtor(&retval);
+                zval_ptr_dtor_nogc(&retval);
         }
 
         if (!Z_ISUNDEF(argv[0])) {
-                zval_dtor(&argv[0]);
+                zval_ptr_dtor_nogc(&argv[0]);
         }
 
         if (!Z_ISUNDEF(argv[1])) {
-                zval_dtor(&argv[1]);
+                zval_ptr_dtor_nogc(&argv[1]);
         }
 
 


### PR DESCRIPTION
zval_dtor() was removed in PHP 8.6 and is just an alias for zval_ptr_dtor_nogc()