### PR TITLE
Update CI checkout action version from v4 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           php-version: ${{ matrix.version }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install gearman on macOS
         if: ${{ matrix.os == 'macos-latest' }}


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to use actions/checkout@v6, the latest major version.

This will eliminate the following messages currently appearing in the CI runs' annotations:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

@rlerdorf: Would you accept a PR to add a GitHub Actions Dependabot workflow? Dependabot would automatically create PRs for updating the CI workflow when new major versions of GitHub Actions are released.

Also, what do you think about adding `CFLAGS=-Werror=incompatible-pointer-types` to the CI builds?