### PR TITLE
Add PHP 8.6 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
         stable: [true]
     steps:
       - name: Setup PHP


### PR DESCRIPTION
## Summary

- Adds PHP 8.6 to the CI build matrix (Linux + macOS)
- No source changes needed — the extension builds cleanly and all 30 non-integration tests pass under PHP 8.6.0-dev

## Test plan

- [x] Built locally against PHP 8.6.0-dev: clean build, no warnings
- [x] `make test`: 30 passed, 0 failed, 43 skipped (online/integration tests)
- CI will now validate PHP 8.6 on every push/PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)