### PR TITLE
Fix build with PHP 8.6.0alpha2

### DIFF
--- a/php_gearman.c
+++ b/php_gearman.c
@@ -97,28 +97,28 @@ PHP_MINIT_FUNCTION(gearman) {
 	gearman_client_ce = zend_register_internal_class(&ce);
 	gearman_client_ce->create_object = gearman_client_obj_new;
 	memcpy(&gearman_client_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_client_obj_handlers));
-	gearman_client_obj_handlers.offset = XtOffsetOf(gearman_client_obj, std);
+	gearman_client_obj_handlers.offset = offsetof(gearman_client_obj, std);
 	gearman_client_obj_handlers.free_obj = gearman_client_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanTask", class_GearmanTask_methods);
 	gearman_task_ce = zend_register_internal_class(&ce);
 	gearman_task_ce->create_object = gearman_task_obj_new;
 	memcpy(&gearman_task_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_task_obj_handlers));
-	gearman_task_obj_handlers.offset = XtOffsetOf(gearman_task_obj, std);
+	gearman_task_obj_handlers.offset = offsetof(gearman_task_obj, std);
 	gearman_task_obj_handlers.free_obj = gearman_task_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanWorker", class_GearmanWorker_methods);
 	gearman_worker_ce = zend_register_internal_class(&ce);
 	gearman_worker_ce->create_object = gearman_worker_obj_new;
 	memcpy(&gearman_worker_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_worker_obj_handlers));
-	gearman_worker_obj_handlers.offset = XtOffsetOf(gearman_worker_obj, std);
+	gearman_worker_obj_handlers.offset = offsetof(gearman_worker_obj, std);
 	gearman_worker_obj_handlers.free_obj = gearman_worker_free_obj;
 
 	INIT_CLASS_ENTRY(ce, "GearmanJob", class_GearmanJob_methods);
 	gearman_job_ce = zend_register_internal_class(&ce);
 	gearman_job_ce->create_object = gearman_job_obj_new;
 	memcpy(&gearman_job_obj_handlers, zend_get_std_object_handlers(), sizeof(gearman_job_obj_handlers));
-	gearman_job_obj_handlers.offset = XtOffsetOf(gearman_job_obj, std);
+	gearman_job_obj_handlers.offset = offsetof(gearman_job_obj, std);
 
 	/* XXX exception class */
 	INIT_CLASS_ENTRY(ce, "GearmanException", NULL)

--- a/php_gearman_client.c
+++ b/php_gearman_client.c
@@ -17,7 +17,7 @@
 #include "php_gearman_client.h"
 
 inline gearman_client_obj *gearman_client_fetch_object(zend_object *obj) {
-       return (gearman_client_obj *)((char*)(obj) - XtOffsetOf(gearman_client_obj, std));
+       return (gearman_client_obj *)((char*)(obj) - offsetof(gearman_client_obj, std));
 }
 
 static void gearman_client_ctor(INTERNAL_FUNCTION_PARAMETERS) {

--- a/php_gearman_job.c
+++ b/php_gearman_job.c
@@ -12,7 +12,7 @@
 #include "php_gearman_job.h"
 
 inline gearman_job_obj *gearman_job_fetch_object(zend_object *obj) {
-        return (gearman_job_obj *)((char*)(obj) - XtOffsetOf(gearman_job_obj, std));
+        return (gearman_job_obj *)((char*)(obj) - offsetof(gearman_job_obj, std));
 }
 
 /* {{{ proto object GearmanJob::__destruct()

--- a/php_gearman_task.c
+++ b/php_gearman_task.c
@@ -12,7 +12,7 @@
 #include "php_gearman_task.h"
 
 inline gearman_task_obj *gearman_task_fetch_object(zend_object *obj) {
-        return (gearman_task_obj *)((char*)(obj) - XtOffsetOf(gearman_task_obj, std));
+        return (gearman_task_obj *)((char*)(obj) - offsetof(gearman_task_obj, std));
 }
 
 inline zend_object *gearman_task_obj_new(zend_class_entry *ce) {

--- a/php_gearman_worker.c
+++ b/php_gearman_worker.c
@@ -16,7 +16,7 @@
 #include "php_gearman_worker.h"
 
 gearman_worker_obj *gearman_worker_fetch_object(zend_object *obj) {
-        return (gearman_worker_obj *)((char*)(obj) - XtOffsetOf(gearman_worker_obj, std));
+        return (gearman_worker_obj *)((char*)(obj) - offsetof(gearman_worker_obj, std));
 }
 
 /* {{{ proto object gearman_worker_ctor()


### PR DESCRIPTION
  . The XtOffsetOf() alias of C’s offsetof() macro has been removed. Use
    offsetof() directly.